### PR TITLE
Fix paging map/unmap logic and `liballoc_alloc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin
+RUN apt-get update && apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin git
 
 RUN groupadd -r simpleuser && useradd --no-log-init -r -g simpleuser simpleuser
 

--- a/src/mmu/alloc.c
+++ b/src/mmu/alloc.c
@@ -37,27 +37,41 @@ int liballoc_unlock() {
 
 void* liballoc_alloc(int number_of_pages) {
     uint64_t first_free_page = 0;
+    uint32_t counter = 0;
 
     for (uint64_t i = 1; i <= max_pages; i++) {
         if (bitmap_get(allocated_pages, i) == false) {
-            first_free_page = i;
-            break;
+
+            counter++;
+
+            if (counter == number_of_pages) {
+
+                first_free_page = i - (counter - 1);
+                break;
+            }
+        } else {
+
+            counter = 0;
         }
     }
 
+    if (first_free_page == 0) {
+
+        PANIC("no free pages for alloc of %d pages", number_of_pages);
+    }
+
     uint64_t addr = page_start_address(heap_start_page + first_free_page);
-    // TODO: I am actually not sure about this, but that should not hurt I
-    // guess.
-    void* ptr = memset((void*)addr, 0, (first_free_page - 1) * PAGE_SIZE);
 
     for (uint64_t i = 0; i < number_of_pages; i++) {
         bitmap_set(allocated_pages, first_free_page + i);
-        map(heap_start_page + first_free_page + i, PAGING_FLAG_WRITABLE);
     }
+
+    map_multiple(heap_start_page + first_free_page, number_of_pages,
+                 PAGING_FLAG_PRESENT | PAGING_FLAG_WRITABLE);
 
     MMU_DEBUG("allocated %d pages at addr=%p", number_of_pages, addr);
 
-    return ptr;
+    return (void*)addr;
 }
 
 int liballoc_free(void* ptr, int number_of_pages) {
@@ -66,8 +80,9 @@ int liballoc_free(void* ptr, int number_of_pages) {
 
     for (uint64_t i = 0; i < number_of_pages; i++) {
         bitmap_clear(allocated_pages, i);
-        unmap(page + i);
     }
+
+    unmap_multiple(page, number_of_pages);
 
     MMU_DEBUG("free'ed ptr=%p page=%u number_of_pages=%d", ptr, page, number_of_pages);
 

--- a/src/mmu/alloc.c
+++ b/src/mmu/alloc.c
@@ -37,26 +37,22 @@ int liballoc_unlock() {
 
 void* liballoc_alloc(int number_of_pages) {
     uint64_t first_free_page = 0;
-    uint32_t counter = 0;
+    uint32_t free_page_count = 0;
 
     for (uint64_t i = 1; i <= max_pages; i++) {
         if (bitmap_get(allocated_pages, i) == false) {
+            free_page_count++;
 
-            counter++;
-
-            if (counter == number_of_pages) {
-
-                first_free_page = i - (counter - 1);
+            if (free_page_count == number_of_pages) {
+                first_free_page = i - (free_page_count - 1);
                 break;
             }
         } else {
-
-            counter = 0;
+            free_page_count = 0;
         }
     }
 
     if (first_free_page == 0) {
-
         PANIC("no free pages for alloc of %d pages", number_of_pages);
     }
 

--- a/src/mmu/paging.c
+++ b/src/mmu/paging.c
@@ -311,17 +311,13 @@ void map(uint64_t page_number, uint64_t flags) {
 }
 
 void map_multiple(uint64_t start_page_number, uint32_t number_of_pages, uint64_t flags) {
-
     for (uint32_t i = 0; i < number_of_pages; i++) {
-
         map(start_page_number + i, flags);
     }
 }
 
 void unmap_multiple(uint64_t start_page_number, uint32_t number_of_pages) {
-
     for (uint32_t i = 0; i < number_of_pages; i++) {
-
         unmap(start_page_number + i);
     }
 }
@@ -334,7 +330,6 @@ uint32_t paging_amount_for_byte_size(uint64_t start_address, uint64_t byte_size)
     uint32_t difference = (uint32_t)(end_page - start_page);
 
     if (difference == 0) {
-
         return 1;
     }
 

--- a/src/mmu/paging.c
+++ b/src/mmu/paging.c
@@ -309,3 +309,34 @@ void map(uint64_t page_number, uint64_t flags) {
 
     map_page_to_frame(page_number, frame, flags);
 }
+
+void map_multiple(uint64_t start_page_number, uint32_t number_of_pages, uint64_t flags) {
+
+    for (uint32_t i = 0; i < number_of_pages; i++) {
+
+        map(start_page_number + i, flags);
+    }
+}
+
+void unmap_multiple(uint64_t start_page_number, uint32_t number_of_pages) {
+
+    for (uint32_t i = 0; i < number_of_pages; i++) {
+
+        unmap(start_page_number + i);
+    }
+}
+
+uint32_t paging_amount_for_byte_size(uint64_t start_address, uint64_t byte_size) {
+
+    uint64_t start_page = page_containing_address(start_address);
+    uint64_t end_page = page_containing_address(start_address + byte_size);
+
+    uint32_t difference = (uint32_t)(end_page - start_page);
+
+    if (difference == 0) {
+
+        return 1;
+    }
+
+    return difference;
+}

--- a/src/mmu/paging.h
+++ b/src/mmu/paging.h
@@ -136,10 +136,11 @@ void unmap(uint64_t page_number);
 void unmap_multiple(uint64_t start_page_number, uint32_t number_of_pages);
 
 /**
- * Calculates how many pages are needed for a range of addresses
+ * Calculates how many pages are needed for a range of addresses.
  *
  * @param start_address the starting virtual address
  * @param byte_size the amount of bytes
+ * @return the amount of pages required for mapping from start_address until start_address + byte_size
  */
 uint32_t paging_amount_for_byte_size(uint64_t start_address, uint64_t byte_size);
 

--- a/src/mmu/paging.h
+++ b/src/mmu/paging.h
@@ -112,7 +112,7 @@ void map_page_to_frame(uint64_t page, uint64_t frame, uint64_t flags);
 void map(uint64_t page_number, uint64_t flags);
 
 /**
- * Maps multiple pages in a row if possible
+ * Maps multiple pages in a row if possible.
  *
  * @param start_page_number the first page of the sequence
  * @param number_of_pages the amount of pages to map
@@ -128,7 +128,7 @@ void map_multiple(uint64_t start_page_number, uint32_t number_of_pages, uint64_t
 void unmap(uint64_t page_number);
 
 /**
- * Unmaps multiple pages
+ * Unmaps multiple consecutive pages.
  *
  * @param start_page_number the first page of the sequence
  * @param number_of_pages the amount of pages to unmap

--- a/src/mmu/paging.h
+++ b/src/mmu/paging.h
@@ -112,10 +112,35 @@ void map_page_to_frame(uint64_t page, uint64_t frame, uint64_t flags);
 void map(uint64_t page_number, uint64_t flags);
 
 /**
+ * Maps multiple pages in a row if possible
+ *
+ * @param start_page_number the first page of the sequence
+ * @param number_of_pages the amount of pages to map
+ * @param flags the paging flags
+ */
+void map_multiple(uint64_t start_page_number, uint32_t number_of_pages, uint64_t flags);
+
+/**
  * Unmaps (free) a page.
  *
  * @param page_number a page number (not an address)
  */
 void unmap(uint64_t page_number);
+
+/**
+ * Unmaps multiple pages
+ *
+ * @param start_page_number the first page of the sequence
+ * @param number_of_pages the amount of pages to unmap
+ */
+void unmap_multiple(uint64_t start_page_number, uint32_t number_of_pages);
+
+/**
+ * Calculates how many pages are needed for a range of addresses
+ *
+ * @param start_address the starting virtual address
+ * @param byte_size the amount of bytes
+ */
+uint32_t paging_amount_for_byte_size(uint64_t start_address, uint64_t byte_size);
 
 #endif


### PR DESCRIPTION
# What does this PR do?

- It fixes some allocation issues with paging
- It adds new helpful methods to paging, which will be used for more accurately mapping things and avoiding page faults
- It fixes an issue where you could overwrite previous mapped pages when allocating with liballoc