### PR TITLE
Fix tar_find_dir

### DIFF
--- a/src/fs/tar.c
+++ b/src/fs/tar.c
@@ -133,7 +133,10 @@ inode_t tar_finddir(inode_t inode, const char* name) {
             header_name[strlen(header_name) - 1] = '\0';
         }
 
-        if (strncmp(fullpath, header_name, strlen(fullpath)) == 0) {
+        size_t header_len = strlen(header_name);
+        size_t fullpath_len = strlen(fullpath);
+
+        if (header_len == fullpath_len && strncmp(fullpath, header_name, fullpath_len) == 0) {
             header = headers[i];
             node->data = i;
             free(header_name);

--- a/test/fs/tar.c
+++ b/test/fs/tar.c
@@ -48,6 +48,8 @@ int main() {
     describe("tar_finddir()");
     inode_t not_found = vfs_namei("/home/will/fileeee");
     assert(not_found == 0, "returns 0 when file is not found");
+    not_found = vfs_namei("/inf");
+    assert(not_found == 0, "returns 0 when partial file name is not found");
 
     inode_t home = vfs_namei("/home");
     assert(vfs_inode_type(home) == FS_DIRECTORY, "can find a directory");


### PR DESCRIPTION
Replaces #30 

Fixes #33

# What does this PR do?

- It fixes tar_find_dir by checking the length of both strings when using `strncmp`

# Remarks

I did basically the same you did in #30, including the test. All tests pass, doing the following commands have the following results:

>> cat /inf
> no such file or directory
>> cat /info
> prints the content of info
>> cat /boo
> no such file or directory
>> cat /booo
> prints the content of booo
>> ls /bin/init
> bin/init is not a directory
>> ls /bin/ini
> no such file or directory

I wanted to work on something for willOS but I was tired from working on ELF loading shenanigans, so I figured I'd help you with this one bit. Thankfully my hipothesis was correct, and you simply had to check if the file paths had the same length before calling strncmp 😄 