### PR TITLE
Added hard drive image support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ $(IMG): $(KERNEL) $(INITRD_TAR)
 	mkdir -p $(GRUB_DIR)
 	cp -R grub/* $(GRUB_DIR)
 	sudo sh makeimg.sh $(IMG) $(ISO_DIR)
+	sudo chown -R ${USER}: $(IMG)
+
 
 run: ## run the OS
 run: $(ISO)

--- a/makeimg.sh
+++ b/makeimg.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+dd if=/dev/zero of=$1 bs=1M count=500
+
+(echo o
+echo n
+echo p
+echo 1
+echo
+echo
+echo a
+echo p
+echo w) | fdisk -u -C500 -S63 -H16 $1
+
+mkdir -p /mnt/osdev
+
+umount /dev/loop0
+umount /dev/loop1
+
+losetup /dev/loop0 $1
+losetup -o1048576 /dev/loop1 $1
+
+mkdosfs -F32 /dev/loop1
+
+mount /dev/loop1 /mnt/osdev
+
+cp -R $2/* /mnt/osdev
+
+echo "(hd0)   /dev/loop0" > device.map
+
+cp device.map /mnt/osdev/boot/grub/device.map
+
+rm device.map
+
+grub-install --no-floppy                                      \
+    --grub-mkdevicemap=/mnt/osdev/boot/grub/device.map              \
+    --modules="biosdisk part_msdos ext2 configfile normal multiboot"\
+    --root-directory=/mnt/osdev                                     \
+    /dev/loop0
+
+sync
+
+umount /dev/loop0
+umount /dev/loop1
+
+losetup -d /dev/loop0
+losetup -d /dev/loop1


### PR DESCRIPTION
# What does this PR do?

- It adds support for generating hard disk drive images (.img), installing GRUB on them, and running them on qemu
- Provides a foundation to start writing some fat32/ext2 filesystem drivers
- It adds the `make img` and `make debug-img` commands to the main makefile.

# Background

It will be most necessary to be able to test on a real hard disk at some point, and since I had already investigated this at my previous attempt at making an OS, I thought it'd be a good idea to doa  PR for willOS too.

Right now it creates a fat32 hard disk but it could easily support ext2 instead if you prefer that.