### PR TITLE
Added stack smash protector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GIT_HASH := $(shell git rev-parse --short HEAD)
 
 CFLAGS = -DGIT_HASH=\"$(GIT_HASH)\" \
 				 -Wall -pedantic -std=c11 -O2 -ffreestanding -nostdlib \
-				 -fno-builtin -fno-stack-protector -mno-red-zone \
+				 -fno-builtin -fstack-protector-all -mno-red-zone \
 				 -I src/include/ -I src/ -I libs/
 
 DEBUG_CFLAGS = -DENABLE_KERNEL_DEBUG -DDEBUG_WITH_COLORS -DDISABLE_MMU_DEBUG

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ run: $(ISO)
 debug: ## build and run the OS in debug mode
 debug: CFLAGS += $(DEBUG_CFLAGS)
 debug: $(ISO)
-	$(QEMU) -cdrom $< -serial file:/tmp/serial.log
+	$(QEMU) -cdrom $< -serial file:/tmp/serial.log -m 1G
 .PHONY: debug
 
 clean: ## remove build artifacts

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -323,7 +323,7 @@ void run_command(const char* command) {
         uptime();
     } else if (strncmp(command, "selftest", 8) == 0) {
         selftest();
-    } else if(strncmp(command, "overflow", 8) == 0) {
+    } else if (strncmp(command, "overflow", 8) == 0) {
         overflowtest();
     } else {
         if (try_exec(command) != 0) {

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -294,6 +294,13 @@ int try_exec(const char* command) {
     return 0;
 }
 
+int overflowtest() {
+
+    char c[12];
+    strcpy(c, "123456789012345678901234567890");
+    return 1;
+}
+
 void run_command(const char* command) {
     DEBUG("command='%s'", command);
 
@@ -317,6 +324,8 @@ void run_command(const char* command) {
         uptime();
     } else if (strncmp(command, "selftest", 8) == 0) {
         selftest();
+    } else if(strncmp(command, "overflow", 8) == 0) {
+        overflowtest();
     } else {
         if (try_exec(command) != 0) {
             printf("invalid kshell command\n");

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -105,7 +105,7 @@ unsigned char keymap[][128] = {
     {0},
 };
 
-#define NB_DOCUMENTED_COMMANDS 6
+#define NB_DOCUMENTED_COMMANDS 8
 
 const char* commands[][NB_DOCUMENTED_COMMANDS] = {
     {"cat", "print on the standard output"},
@@ -115,6 +115,7 @@ const char* commands[][NB_DOCUMENTED_COMMANDS] = {
     {"ls", "list files"},
     {"selftest", "run the willOS test suite"},
     {"uptime", "tell how long the system has been running"},
+    {"overflow", "test the stack buffer overflow protection"},
 };
 
 unsigned char get_char(uint8_t scancode, bool shift, bool caps_lock) {
@@ -294,7 +295,7 @@ int try_exec(const char* command) {
     return 0;
 }
 
-int overflowtest() {
+int overflow() {
     char c[12];
     strcpy(c, "123456789012345678901234567890");
     return 1;
@@ -324,7 +325,7 @@ void run_command(const char* command) {
     } else if (strncmp(command, "selftest", 8) == 0) {
         selftest();
     } else if (strncmp(command, "overflow", 8) == 0) {
-        overflowtest();
+        overflow();
     } else {
         if (try_exec(command) != 0) {
             printf("invalid kshell command\n");

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -295,7 +295,6 @@ int try_exec(const char* command) {
 }
 
 int overflowtest() {
-
     char c[12];
     strcpy(c, "123456789012345678901234567890");
     return 1;

--- a/src/libc/stackguard.c
+++ b/src/libc/stackguard.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef __is_libk
+#ifndef __is_libc
 #include <kernel/panic.h>
 #endif
 
@@ -18,7 +18,7 @@ uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
 void __stack_chk_fail(void)
 {
 #ifdef __is_libc
-printf("Stack Smashing Detected (TODO: Abort() impl)");
+printf("Stack Smashing Detected (TODO: abort() impl)");
 #else
 PANIC("Stack Smashing Detected");
 #endif

--- a/src/libc/stackguard.c
+++ b/src/libc/stackguard.c
@@ -15,11 +15,10 @@ uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
  * Basic stack smashing protector implementation
  * Based on https://wiki.osdev.org/Stack_Smashing_Protector
  */
-void __stack_chk_fail(void)
-{
+void __stack_chk_fail(void) {
 #ifdef __is_libc
-printf("Stack Smashing Detected (TODO: abort() impl)");
+    printf("Stack Smashing Detected (TODO: abort() impl)");
 #else
-PANIC("Stack Smashing Detected");
+    PANIC("Stack Smashing Detected");
 #endif
 }

--- a/src/libc/stackguard.c
+++ b/src/libc/stackguard.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef __is_libk
+#include <kernel/panic.h>
+#endif
+
+//TODO: Make this value randomized
+#define STACK_CHK_GUARD 0x595e9fbd94fda766
+
+uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
+
+/**
+ * Basic stack smashing protector implementation
+ * Based on https://wiki.osdev.org/Stack_Smashing_Protector
+ */
+void __stack_chk_fail(void)
+{
+#ifdef __is_libc
+printf("Stack Smashing Detected (TODO: Abort() impl)");
+#else
+PANIC("Stack Smashing Detected");
+#endif
+}

--- a/userland/init/Makefile
+++ b/userland/init/Makefile
@@ -12,7 +12,7 @@ TARGET   = $(BIN_DIR)/init
 # executable if needed, see: https://access.redhat.com/blogs/766093/posts/1975793
 CFLAGS = -Wl,-emain -Wall -pedantic -std=c11 -O2 -ffreestanding -nostdlib \
 				 -D__is_libc \
-				 -fno-builtin -fno-stack-protector -I $(ROOT_DIR)/src/include/ -I $(ROOT_DIR)/libs/
+				 -fno-builtin -fstack-protector-all -I $(ROOT_DIR)/src/include/ -I $(ROOT_DIR)/libs/
 LIBS   = $(ROOT_DIR)/build/libc-willOS.a
 
 default: $(TARGET)

--- a/userland/init/init.c
+++ b/userland/init/init.c
@@ -5,7 +5,7 @@
 
 #define READLINE_SIZE           256
 #define PROMPT                  "(init) "
-#define NB_DOCUMENTED_COMMANDS  7
+#define NB_DOCUMENTED_COMMANDS  8
 
 void date() {
     printf("implement me\n");
@@ -38,6 +38,7 @@ int main() {
         {"help", "display information about willOS shell commands"},
         {"reboot", "stopping and restarting the system"},
         {"uptime", "tell how long the system has been running"},
+        {"overflow", "test the stack buffer overflow protection"},
     };
 
     char readline[READLINE_SIZE] = {0};

--- a/userland/init/init.c
+++ b/userland/init/init.c
@@ -101,7 +101,7 @@ int main() {
                     reboot();
                 } else if (strncmp(readline, "uptime", 6) == 0) {
                     uptime();
-                } else if(strncmp(readline, "overflow", 8) == 0) {
+                } else if (strncmp(readline, "overflow", 8) == 0) {
                     overflow();
                 } else {
                     printf("invalid command\n");

--- a/userland/init/init.c
+++ b/userland/init/init.c
@@ -23,6 +23,12 @@ void uptime() {
     printf("implement me\n");
 }
 
+int overflow() {
+    char c[12];
+    strcpy(c, "123456789012345678901234567890");
+    return 1;
+}
+
 int main() {
     const char* commands[][NB_DOCUMENTED_COMMANDS] = {
         {"cal", "displays a calendar"},
@@ -95,6 +101,8 @@ int main() {
                     reboot();
                 } else if (strncmp(readline, "uptime", 6) == 0) {
                     uptime();
+                } else if(strncmp(readline, "overflow", 8) == 0) {
+                    overflow();
                 } else {
                     printf("invalid command\n");
                 }


### PR DESCRIPTION
# What does this PR do?

- It adds a stack smash protector that detects stack buffer overflows
- It adds an "overflow" kshell command for testing the protector

# Background

Base taken from https://wiki.osdev.org/Stack_Smashing_Protector with working example from https://en.wikipedia.org/wiki/Stack_buffer_overflow . 
The way stack buffer overflow basically works is that the compiler has support for a stack protector, and if we provide a couple fields, it's able to detect when we overwrite a memory area before returning a value.

An example that you can see in the previously posted link is something like this:

```c
char c[12];
strcpy(c, "12345678901234567890"); //Exceeds the 12 characters of the string
return 1; //Will cause the trigger here
```

I will test this in userland after posting this PR.