### PR TITLE
Cleanup some parts with clang-tidy

### DIFF
--- a/src/core/boot.c
+++ b/src/core/boot.c
@@ -1,6 +1,6 @@
 #include "boot.h"
-#include <stdio.h>
 #include <core/debug.h>
+#include <stdio.h>
 
 void* find_multiboot_tag(multiboot_info_t* mbi, uint16_t type) {
     for (
@@ -128,12 +128,12 @@ reserved_areas_t find_reserved_areas(multiboot_info_t* mbi) {
                         continue;
                     }
 
-                    if (((uint64_t)(elf->addr)) < reserved.kernel_start) {
-                        reserved.kernel_start = (uint64_t) elf->addr;
+                    if (((elf->addr)) < reserved.kernel_start) {
+                        reserved.kernel_start = elf->addr;
                     }
 
-                    if (((uint64_t)(elf->addr)) + elf->size > reserved.kernel_end) {
-                        reserved.kernel_end = (uint64_t) elf->addr;
+                    if (((elf->addr)) + elf->size > reserved.kernel_end) {
+                        reserved.kernel_end = elf->addr;
                         reserved.kernel_end += elf->size;
                     }
                 }

--- a/src/core/cmos.c
+++ b/src/core/cmos.c
@@ -27,7 +27,9 @@ cmos_rtc_t cmos_read_rtc() {
 
     // This uses the "read registers until you get the same values twice in a
     // row" technique to avoid getting inconsistent values due to RTC updates
-    while (update_in_progress()) ;
+    while (update_in_progress()) {
+        ;
+    }
 
     // read a first time
     rtc.seconds = read_register(CMOS_REG_SECONDS);
@@ -43,7 +45,9 @@ cmos_rtc_t cmos_read_rtc() {
         // prepare to read a second time
         memcpy(&last, &rtc, sizeof(cmos_rtc_t));
 
-        while (update_in_progress()) ;
+        while (update_in_progress()) {
+            ;
+        }
 
         // read a second time
         rtc.seconds = read_register(CMOS_REG_SECONDS);

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -18,7 +18,7 @@ static const uint16_t serial_com1 = SERIAL_COM1;
 // qemu config in `Makefile`). That would not work otherwise, I think.
 #define DEBUG(format, ...)  fctprintf(&serial_stream_output, \
                             (void*)&serial_com1, \
-                            "%sDEBUG%s %s%s:%d:%s():%s " format "\n", \
+                            "%sDEBUG%s %s%s:%ld:%s():%s " format "\n", \
                             ANSICOLOR_FG_CYAN, \
                             ANSICOLOR_RESET, \
                             ANSICOLOR_FG_LIGHTGRAY, \
@@ -29,7 +29,7 @@ static const uint16_t serial_com1 = SERIAL_COM1;
 
 #define DEBUG(format, ...)  fctprintf(&serial_stream_output, \
                             (void*)&serial_com1, \
-                            "DEBUG %s:%d:%s(): " format "\n", \
+                            "DEBUG %s:%ld:%s(): " format "\n", \
                             __FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #endif

--- a/src/core/syscall.c
+++ b/src/core/syscall.c
@@ -4,10 +4,10 @@
 #include <drivers/keyboard.h>
 #include <drivers/screen.h>
 #include <kernel/panic.h>
-#include <sys/syscall.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
+#include <sys/syscall.h>
 
 syscall_handler_t syscall_handlers[NB_SYSCALLS];
 
@@ -57,7 +57,7 @@ void syscall_gettimeofday(registers_t* registers) {
     struct timeval* t = registers->rbx;
 
     t->tv_sec = cmos_boot_time() + timer_uptime();
-    // TODO: set a correct value, see:
+    // TODO(william): set a correct value, see:
     // https://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html
     t->tv_usec = 0;
 

--- a/src/drivers/screen.c
+++ b/src/drivers/screen.c
@@ -1,8 +1,8 @@
 #include "screen.h"
-#include <string.h>
-#include <stddef.h>
-#include <core/port.h>
 #include <core/debug.h>
+#include <core/port.h>
+#include <stddef.h>
+#include <string.h>
 
 #define FB_COMMAND_PORT         0x3D4
 #define FB_DATA_PORT            0x3D5

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -1,15 +1,15 @@
 #include "serial.h"
 #include <core/port.h>
-#include <string.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 
 void serial_write(uint16_t com, char c);
 bool serial_received(uint16_t com);
 bool serial_is_transmit_fifo_empty(uint16_t com);
-// TODO: could be exposed later if needed
+// TODO(william): could be exposed later if needed
 char serial_read(uint16_t com);
 
 void serial_init(uint16_t com, uint16_t speed) {
@@ -52,13 +52,17 @@ bool serial_received(uint16_t com) {
 }
 
 char serial_read(uint16_t com) {
-    while (serial_received(com) == 0) ;
+    while (serial_received(com) == 0) {
+        ;
+    }
 
     return port_byte_in(com);
 }
 
 void serial_write(uint16_t com, char c) {
-    while (serial_is_transmit_fifo_empty(com) == 0) ;
+    while (serial_is_transmit_fifo_empty(com) == 0) {
+        ;
+    }
 
     port_byte_out(com, c);
 }

--- a/src/fs/debug.c
+++ b/src/fs/debug.c
@@ -38,7 +38,7 @@ uint64_t debug_stat(inode_t node, stat_t* st) {
 
 uint64_t debug_write(inode_t node, void* buffer, uint64_t size, uint64_t offset) {
     if (offset < size) {
-        printf(&buffer[offset]);
+        printf("%s", &buffer[offset]);
         return size - offset;
     }
 

--- a/src/fs/tar.c
+++ b/src/fs/tar.c
@@ -80,7 +80,7 @@ uint64_t get_size(const char* in) {
 }
 
 uint64_t tar_read(inode_t node, void* buffer, uint64_t size, uint64_t offset) {
-    DEBUG("name=%s type=%d size=%u offset=%u", node->name, vfs_inode_type(node), size, offset);
+    DEBUG("name=%s type=%d size=%lu offset=%lu", node->name, vfs_inode_type(node), size, offset);
     // Empty buffer.
     strcpy(buffer, "");
 
@@ -96,7 +96,7 @@ uint64_t tar_read(inode_t node, void* buffer, uint64_t size, uint64_t offset) {
             offset = size;
         }
 
-        DEBUG("copying %d bytes (offset=%u header_size=%d)", size, offset, header_size);
+        DEBUG("copying %ld bytes (offset=%lu header_size=%ld)", size, offset, header_size);
 
         memcpy(buffer, (void*)header + 512 + offset, size);
         ((char*)buffer)[size] = '\0';
@@ -104,7 +104,7 @@ uint64_t tar_read(inode_t node, void* buffer, uint64_t size, uint64_t offset) {
         return size - offset;
     }
 
-    // TODO: add support for other types like symlinks (at least)
+    // TODO(william): add support for other types like symlinks (at least)
 
     return 0;
 }
@@ -168,7 +168,7 @@ inode_t tar_finddir(inode_t inode, const char* name) {
             break;
     }
 
-    DEBUG("found name=%s type=%d", node->name, node->type);
+    DEBUG("found name=%s type=%ld", node->name, node->type);
 
     return node;
 }

--- a/src/fs/vfs.c
+++ b/src/fs/vfs.c
@@ -1,7 +1,7 @@
 #include "vfs.h"
-#include <string.h>
-#include <stdlib.h>
 #include <core/debug.h>
+#include <stdlib.h>
+#include <string.h>
 
 inode_t vfs_find_root(char** path);
 inode_t vfs_namei_mount(const char* path, inode_t root);
@@ -94,7 +94,9 @@ dirent_t* vfs_readdir(inode_t inode, uint64_t num) {
             ret->inode = inode;
             strcpy(ret->name, ".");
             return ret;
-        } else if (num == 1) {
+        }
+
+        if (num == 1) {
             dirent_t* ret = malloc(sizeof(dirent_t));
             ret->inode = inode->parent;
             strcpy(ret->name, "..");
@@ -113,7 +115,9 @@ inode_t vfs_finddir(inode_t inode, const char* name) {
     if (vfs_inode_type(inode) == FS_DIRECTORY) {
         if (!strncmp(name, ".", strlen(name))) {
             return inode;
-        } else if (!strncmp(name, "..", strlen(name))) {
+        }
+
+        if (!strncmp(name, "..", strlen(name))) {
             return inode->parent;
         }
     }
@@ -184,7 +188,7 @@ inode_t vfs_find_root(char** path) {
 
     DEBUG("found root=%s", mount->name);
 
-    return (inode_t)mount;
+    return mount;
 }
 
 inode_t vfs_namei_mount(const char* path, inode_t root) {
@@ -268,7 +272,7 @@ inode_t vfs_namei(const char* path) {
 
 inode_t vfs_umount(const char* path) {
     DEBUG("umounting path=%s", path);
-    // TODO: implement me
+    // TODO(william): implement me
     return 0;
 }
 

--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -9,9 +9,9 @@
 #include <drivers/screen.h>
 #include <drivers/screen.h>
 #include <drivers/serial.h>
-#include <fs/vfs.h>
 #include <fs/debug.h>
 #include <fs/tar.h>
+#include <fs/vfs.h>
 #include <kernel/kshell.h>
 #include <kernel/panic.h>
 #include <mmu/alloc.h>
@@ -58,7 +58,9 @@ void check_interrupts() {
 
     uint32_t tick = timer_tick();
 
-    while (tick == timer_tick()) ;
+    while (tick == timer_tick()) {
+        ;
+    }
 
     print_ok();
 }

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -6,11 +6,11 @@
 #include <drivers/screen.h>
 #include <fs/debug.h>
 #include <fs/vfs.h>
-#include <sys/syscall.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
+#include <sys/syscall.h>
 
 unsigned char keymap[][128] = {
     {0},
@@ -164,7 +164,7 @@ void clear() {
 }
 
 void uptime() {
-    printf("up %u seconds\n", timer_uptime());
+    printf("up %llu seconds\n", timer_uptime());
 }
 
 void print_selftest_header(const char* name) {
@@ -250,7 +250,7 @@ void ls(const char* command) {
 
         stat_t stat;
         vfs_stat(de->inode, &stat);
-        printf("%6d %s\n", stat.size, de->name);
+        printf("%6llu %s\n", stat.size, de->name);
 
         free(de);
     }
@@ -301,7 +301,7 @@ void run_command(const char* command) {
         return;
     }
 
-    // TODO: implement and use `strktok()` to get the command and the arguments.
+    // TODO(william): implement and use `strktok()` to get the command and the arguments.
 
     if (strncmp(command, "help", 4) == 0) {
         help(command);
@@ -366,7 +366,7 @@ void kshell_run(uint8_t scancode) {
             if (key_was_released) {
                 reset_readline();
                 strncpy(readline, last_readline, READLINE_SIZE);
-                printf(readline);
+                printf("%s", readline);
                 readline_index = strlen(readline);
             }
 

--- a/src/libc/string/strsep.c
+++ b/src/libc/string/strsep.c
@@ -1,5 +1,5 @@
-#include <string.h>
 #include <core/debug.h>
+#include <string.h>
 
 char* strsep(char** str, const char* sep) {
     char* s = *str, *end;

--- a/src/libc/time/localtime.c
+++ b/src/libc/time/localtime.c
@@ -32,8 +32,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * WITH THE SOFTWARE.
  */
-#include <time.h>
 #include <sys/syscall.h>
+#include <time.h>
 
 #define SEC_DAY 86400
 
@@ -131,27 +131,31 @@ struct tm* localtime_r(const time_t* timep, struct tm* _timevalue) {
                                     _timevalue->tm_yday = (*timep - year_sec) / SEC_DAY;
                                     _timevalue->tm_isdst = 0; // never because UTC
                                     return _timevalue;
-                                } else {
-                                    seconds += secs;
                                 }
+
+                                seconds += secs;
+
                             }
 
                             return NULL;
-                        } else {
-                            seconds += secs;
                         }
+
+                        seconds += secs;
+
                     }
 
                     return NULL;
-                } else {
-                    seconds += secs;
                 }
+
+                seconds += secs;
+
             }
 
             return NULL;
-        } else {
-            seconds += secs;
         }
+
+        seconds += secs;
+
     }
 
     return (void*)0; // uh what

--- a/src/libc/time/strftime.c
+++ b/src/libc/time/strftime.c
@@ -33,9 +33,9 @@
  * WITH THE SOFTWARE.
  */
 #include <stddef.h>
-#include <time.h>
-#include <sys/time.h>
 #include <stdio.h>
+#include <sys/time.h>
+#include <time.h>
 
 static char* weekdays[] = {
     "Sunday",

--- a/src/mmu/bitmap.c
+++ b/src/mmu/bitmap.c
@@ -1,6 +1,6 @@
 #include "bitmap.h"
 
-bool bitmap_get(bitmap_t* b, uint64_t n) {
+bool bitmap_get(const bitmap_t* b, uint64_t n) {
     return b[WORD_OFFSET(n)] & ((bitmap_t)1 << (BIT_OFFSET(n))) ? true : false;
 }
 

--- a/src/mmu/bitmap.h
+++ b/src/mmu/bitmap.h
@@ -21,7 +21,7 @@ enum { BITS_PER_WORD = sizeof(bitmap_t) * CHAR_BIT };
  * @param n the bit to check
  * @return `true` when the bit to check is set, `false` otherwise
  */
-bool bitmap_get(bitmap_t* b, uint64_t n);
+bool bitmap_get(const bitmap_t* b, uint64_t n);
 
 /**
  * Sets a bit (sets it to `true`).

--- a/src/mmu/paging.c
+++ b/src/mmu/paging.c
@@ -1,6 +1,6 @@
 #include "paging.h"
-#include <mmu/debug.h>
 #include <kernel/panic.h>
+#include <mmu/debug.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,8 +8,8 @@
 #define MMU_DEBUG_PAGE_ENTRY(message, e)  MMU_DEBUG("%s " \
                                           "page entry addr=%p present=%d " \
                                           "writable=%d no_execute=%d", \
-                                          message, e.addr, e.present, \
-                                          e.writable, e.no_execute)
+                                          message, (e).addr, (e).present, \
+                                          (e).writable, (e).no_execute)
 
 void zero_table(page_table_t* table);
 page_table_t* next_table_address(page_table_t* table, uint64_t index);
@@ -39,7 +39,7 @@ page_table_t* next_table_address(page_table_t* table, uint64_t index) {
 
     if (table->entries[index].huge_page == 1) {
         MMU_DEBUG("huge page detected for table=%p index=%u, returning 0", table, index);
-        // TODO: fix this problem. Huge page is detected and we are not able to
+        // TODO(william): fix this problem. Huge page is detected and we are not able to
         // create a page table because of this. This prevents an ELF to load...
         // That's pretty bad :(
         //return 0;
@@ -90,9 +90,10 @@ uint64_t translate_page(uint64_t page_number) {
             frame_number += p2_index(page_number) * PAGE_ENTRIES + p1_index(page_number);
 
             return frame_number;
-        } else {
-            PANIC("misaligned 1GB page=%u", page_number);
         }
+
+        PANIC("misaligned 1GB page=%u", page_number);
+
     }
 
     if (p3 == 0) {
@@ -110,9 +111,10 @@ uint64_t translate_page(uint64_t page_number) {
             frame_number += p1_index(page_number);
 
             return frame_number;
-        } else {
-            PANIC("misaligned 2MB page=%u", page_number);
         }
+
+        PANIC("misaligned 2MB page=%u", page_number);
+
     }
 
     if (p2 == 0) {
@@ -148,7 +150,7 @@ uint64_t p1_index(uint64_t page) {
 
 uint64_t pointed_frame(page_entry_t entry) {
     if (entry.present) {
-        return frame_containing_address((uint64_t)entry.addr);
+        return frame_containing_address(entry.addr);
     }
 
     return 0;
@@ -289,7 +291,7 @@ void unmap(uint64_t page_number) {
     memset(&p1->entries[p1_index(page_number)], 0, sizeof(page_entry_t));
     MMU_DEBUG_PAGE_ENTRY("cleared", p1->entries[p1_index(page_number)]);
 
-    // TODO: free p(1,2,3) table if empty
+    // TODO(william): free p(1,2,3) table if empty
 
     frame_deallocate(frame_number);
 


### PR DESCRIPTION
I started to evaluate clang-tidy/clang-format to automatically fix trivial mistakes and/or autoformat the code.