### PR TITLE
Require clang-format 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,15 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/buildpack-deps
+      - image: cimg/base:2020.01
     steps:
       - checkout
       - run:
           name: install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin
+            sudo apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin clang-format-9
+            sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
       - run:
           name: build
           command: |
@@ -23,7 +24,7 @@ jobs:
           name: test
           command: make clean test
       - run:
-          name: astyle
+          name: fmt
           command: |
             make fmt
             git diff --exit-code || (echo "\n\nPlease run 'make fmt' to format the code and fix the problem(s) above"; false)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin git clang-format
+RUN apt-get update && apt-get install -y nasm xorriso build-essential grub2-common grub-pc-bin git clang-format-9
+
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
 
 RUN groupadd -r simpleuser && useradd --no-log-init -r -g simpleuser simpleuser
 


### PR DESCRIPTION
Fixes #48

It fixes the issue by providing a Docker image with working tools so one can run:

```
docker run --rm -v $(pwd):/app willos/toolchain make fmt
```