### PR TITLE
Remove bugged bitmap usage in alloc

### DIFF
--- a/src/mmu/alloc.h
+++ b/src/mmu/alloc.h
@@ -6,6 +6,8 @@
 #define HEAP_START 0x40000000
 /// The size of the heap.
 #define HEAP_SIZE 200 * 1024 // 200 KiB
+/// The number of pages that we can allocate.
+#define MAX_PAGES HEAP_SIZE / PAGE_SIZE
 
 /**
  * Initializes the heap memory allocator.

--- a/test/mmu/bitmap.c
+++ b/test/mmu/bitmap.c
@@ -4,10 +4,16 @@
 
 int main()
 {
-  bitmap_t b[1];
+  bitmap_t b[2];
+
+  describe("bitmap init");
+  memset(b, 0, sizeof(bitmap_t) * 2);
+  for (uint32_t i = 0; i < BITS_PER_WORD * 2; i++) {
+    assert(!bitmap_get(b, i), "returns false by default");
+  }
+  end_describe();
 
   describe("bitmap get()/set()/clear()");
-  assert(!bitmap_get(b, 0), "returns false when not set");
   bitmap_set(b, 0);
   assert(bitmap_get(b, 0), "returns true after set");
   bitmap_clear(b, 0);


### PR DESCRIPTION
For some reasons, a few bits are set to `1` in the `allocated_pages` bitmap, even after `memset()`. I tried to reset all the bits with a loop and `bitmap_clear()` but all I got was a General Fault Protection... Let's make this allocator dumb for now.