### PR TITLE
Fix libc/libk compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ CFLAGS = -DKERNEL_NAME=\"$(OS_NAME)\" \
 	 -DGIT_HASH=\"$(GIT_HASH)\" \
 	 -Wall -pedantic -std=c11 -O0 -ffreestanding -nostdlib \
 	 -fno-builtin -fstack-protector -mno-red-zone \
-	 -I src/include/ -I src/ -I libs/
+	 -I src/ -I src/include/ -I libs/
 
 DEBUG_CFLAGS = -DENABLE_KERNEL_DEBUG -DDEBUG_WITH_COLORS -DDISABLE_MMU_DEBUG
 

--- a/src/include/stdio.h
+++ b/src/include/stdio.h
@@ -9,7 +9,7 @@
  */
 void _putchar(char c);
 
-#ifdef __is_libc
+#ifndef __is_libk
 
 /**
  * Writes a character to the screen.

--- a/src/include/stdlib.h
+++ b/src/include/stdlib.h
@@ -5,10 +5,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __is_libk
+
 #define _HAVE_SIZE_T
 #define _HAVE_UINTPTR_T
 
 #include <liballoc/liballoc.h>
+
+#endif
 
 int atoi(char* s);
 

--- a/src/include/string.h
+++ b/src/include/string.h
@@ -3,6 +3,14 @@
 
 #include <stddef.h>
 
+// This is needed because `strdup()` relies on `malloc()`, which isn't
+// available in the `libc` yet.
+#ifdef __is_libk
+
+char* strdup(const char* s);
+
+#endif
+
 size_t strlen(const char* s);
 
 int strcmp(const char* s1, const char* s2);
@@ -17,8 +25,6 @@ char* strncpy(char* dest, const char* src, size_t len);
 char* strsep(char** str, const char* sep);
 
 int strcspn(const char* s1, const char* s2);
-
-char* strdup(const char* s);
 
 char* strcat(char* dest, const char* src);
 

--- a/src/include/sys/types.h
+++ b/src/include/sys/types.h
@@ -10,7 +10,6 @@ typedef uint64_t size_t;
 typedef int64_t ssize_t;
 typedef int64_t off_t;
 
-#ifndef __is_libc
 typedef struct opt_uint8
 {
   bool has_value;
@@ -40,6 +39,5 @@ typedef struct opt_bool
   bool has_value;
   bool value;
 } opt_bool_t;
-#endif
 
 #endif

--- a/src/libc/putchar.c
+++ b/src/libc/putchar.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 
-#ifdef __is_libc
 #include <proc/descriptor.h>
 #include <sys/syscall.h>
 
@@ -8,4 +7,3 @@ void putchar(char c)
 {
   write(STDOUT, &c, 1);
 }
-#endif

--- a/src/libc/stackguard.c
+++ b/src/libc/stackguard.c
@@ -2,8 +2,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifndef __is_libc
+#ifdef __is_libk
+
 #include <kernel/panic.h>
+
 #endif
 
 // TODO: Make this value randomized
@@ -17,9 +19,9 @@ uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
  */
 void __stack_chk_fail(void)
 {
-#ifdef __is_libc
-  printf("Stack Smashing Detected (TODO: abort() impl)\n");
-#else
+#ifdef __is_libk
   PANIC("Stack Smashing Detected");
+#else
+  printf("Stack Smashing Detected (TODO: abort() impl)\n");
 #endif
 }

--- a/src/libc/string/strdup.c
+++ b/src/libc/string/strdup.c
@@ -1,6 +1,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+// This is needed because `strdup()` relies on `malloc()`, which isn't
+// available in the `libc` yet.
+#ifdef __is_libk
+
 char* strdup(const char* s)
 {
   size_t len = strlen(s) + 1;
@@ -12,3 +16,5 @@ char* strdup(const char* s)
 
   return ret;
 }
+
+#endif

--- a/userland/Makefile.include
+++ b/userland/Makefile.include
@@ -11,11 +11,13 @@ TARGET   = $(BIN_DIR)/$(BIN_NAME)
 LOCAL_BUILD_DIR = ../local-build
 LOCAL_BUILD_TARGET = $(LOCAL_BUILD_DIR)/$(BIN_NAME)
 
+PLATFORM = $(shell echo __$(OS_NAME)__ | tr '[:upper:]' '[:lower:]')
+
 # Add `-no-pie` to disable the PIE feature that causes `gcc` to not create an
 # executable if needed, see: https://access.redhat.com/blogs/766093/posts/1975793
-CFLAGS = -Wl,-emain -Wall -pedantic -std=c11 -O0 -ffreestanding -nostdlib \
-				 -D__is_libc \
-				 -fno-builtin -I $(ROOT_DIR)/src/include/ -I $(ROOT_DIR)/libs/ \
+CFLAGS = -Wl,-emain -Wall -pedantic -std=c11 -O0 -ffreestanding -nostdlib -fno-builtin \
+				 -D$(PLATFORM) \
+				 -I $(ROOT_DIR)/src/include/ -I $(ROOT_DIR)/libs/ \
 				 -no-pie -fno-pie
 LIBS   = $(ROOT_DIR)/build/libc-$(OS_NAME).a
 

--- a/userland/hostname/main.c
+++ b/userland/hostname/main.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifdef __is_libc
+#ifdef __willos__
 #define HOSTNAME_FILE "/proc/hostname"
 #else
 #define HOSTNAME_FILE "/proc/sys/kernel/hostname"

--- a/userland/shell/reboot.c
+++ b/userland/shell/reboot.c
@@ -5,7 +5,7 @@
 
 void _reboot()
 {
-#ifdef __is_libc
+#ifdef __willos__
   printf("Restarting system now...\n");
   reboot(REBOOT_CMD_RESTART);
 #else


### PR DESCRIPTION
This patch also exposes `__willos__` in the userland programs so that we can
conditionally require header files (depending on the platform).