### PR TITLE
libc: add initial implementation of the `abort()` function

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -27,4 +27,6 @@ int abs(int x);
 
 long int strtol_wip(const char* str, char** end, int base);
 
+void abort();
+
 #endif

--- a/src/libc/abort.c
+++ b/src/libc/abort.c
@@ -1,0 +1,16 @@
+#ifndef __is_libk
+#include <stdio.h>
+#include <stdlib.h>
+
+__attribute__((__noreturn__)) void abort()
+{
+  // TODO: abnormally terminate the process as if by SIGABRT.
+  printf("abort() was called\n");
+
+  while (1) {
+    ;
+  }
+  __builtin_unreachable();
+}
+
+#endif


### PR DESCRIPTION
This PR adds a new `abort()` function in the libc (only). It should probably use a syscall eventually.