### PR TITLE
Fix sendto()/recvfrom() syscalls

### DIFF
--- a/src/libc/asm/syscall.asm
+++ b/src/libc/asm/syscall.asm
@@ -1,11 +1,12 @@
 global syscall
 
 syscall:
-  mov rax, rdi
-  mov rdi, rsi
-  mov rsi, rdx
-  mov rdx, rcx
-  mov r10, r8
-  mov r8, r9
+  mov rax, rdi      ; syscall number
+  mov rdi, rsi      ; 1st arg
+  mov rsi, rdx      ; 2nd arg
+  mov rdx, rcx      ; 3rd arg
+  mov r10, r8       ; 4th arg
+  mov r8, r9        ; 5th arg
+  mov r9, [rsp + 8] ; 6th arg
   syscall
   ret

--- a/src/libc/sys/recvfrom.c
+++ b/src/libc/sys/recvfrom.c
@@ -9,17 +9,17 @@ ssize_t recvfrom(int sockfd,
 {
   ssize_t retval;
 
-  // We implement blocking here because the kernel does not run mulitple
+  // We implement blocking here because the kernel does not run multiple
   // processes/threads. It cannot be done in the syscall handler either because
   // it would block everything else.
   do {
 #ifdef __is_libk
-    retval = k_recvfrom(sockfd, buf, len, /* flags, */ src_addr, addrlen);
+    retval = k_recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
 #else
     errno = 0;
 
-    retval = syscall(
-      SYSCALL_RECVFROM, sockfd, buf, len, /* flags, */ src_addr, addrlen);
+    retval =
+      syscall(SYSCALL_RECVFROM, sockfd, buf, len, flags, src_addr, addrlen);
 
     SYSCALL_SET_ERRNO();
 #endif

--- a/src/libc/sys/sendto.c
+++ b/src/libc/sys/sendto.c
@@ -8,12 +8,12 @@ ssize_t sendto(int sockfd,
                socklen_t addrlen)
 {
 #ifdef __is_libk
-  return k_sendto(sockfd, buf, len, /* flags, */ dst_addr, addrlen);
+  return k_sendto(sockfd, buf, len, flags, dst_addr, addrlen);
 #else
   errno = 0;
 
   ssize_t retval =
-    syscall(SYSCALL_SENDTO, sockfd, buf, len, /* flags, */ dst_addr, addrlen);
+    syscall(SYSCALL_SENDTO, sockfd, buf, len, flags, dst_addr, addrlen);
 
   SYSCALL_SET_ERRNO();
 

--- a/src/sys/k_recvfrom.c
+++ b/src/sys/k_recvfrom.c
@@ -9,12 +9,13 @@
 ssize_t k_recvfrom(int sockfd,
                    void* buf,
                    size_t len,
-                   /* int flags, */
+                   int flags,
                    struct sockaddr* src_addr,
                    socklen_t* addrlen)
 {
   UNUSED(addrlen);
   UNUSED(src_addr);
+  UNUSED(flags);
 
   if (sockfd < 3) {
     SYS_DEBUG("invalid socket descriptor sd=%d", sockfd);

--- a/src/sys/k_sendto.c
+++ b/src/sys/k_sendto.c
@@ -1,5 +1,6 @@
 #include "k_syscall.h"
 #include "logging.h"
+#include <core/utils.h>
 #include <errno.h>
 #include <net/net.h>
 #include <net/udp.h>
@@ -9,10 +10,12 @@
 ssize_t k_sendto(int sockfd,
                  const void* buf,
                  size_t len,
-                 /* int flags, */
+                 int flags,
                  const struct sockaddr* dst_addr,
                  socklen_t addrlen)
 {
+  UNUSED(flags);
+
   if (sockfd < 3) {
     SYS_DEBUG("invalid socket descriptor sd=%d", sockfd);
     return -ENOTSOCK;

--- a/src/sys/k_syscall.h
+++ b/src/sys/k_syscall.h
@@ -27,7 +27,7 @@ int k_reboot(int command);
 ssize_t k_sendto(int sockfd,
                  const void* buf,
                  size_t len,
-                 /* int flags, */
+                 int flags,
                  const struct sockaddr* dst_addr,
                  socklen_t addrlen);
 int k_socket(int domain, int type, int protocol);
@@ -36,7 +36,7 @@ void k_test(const char* s);
 ssize_t k_recvfrom(int sockfd,
                    void* buf,
                    size_t len,
-                   /* int flags, */
+                   int flags,
                    struct sockaddr* src_addr,
                    socklen_t* addrlen);
 int k_gethostbyname2(const char* name, struct in_addr* in);


### PR DESCRIPTION
Fixes #200

---

We can now pass up to 6 parameters to a syscall.