### PR TITLE
Refactor frame allocator and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,42 @@ $ make clean GRUB_KERNEL_CMDLINE="/bin/init foo bar" run-debug
 10. Call the C `kmain()` function
 11. Eventually switch to user mode and call `/bin/init` by default
 
+## Memory management
+
+During the early boot sequence, we identity map the first gigabyte of our kernel
+with 512 2MiB pages. When `kmain()` is called, we call `paging_init()` to update
+the mapping:
+
+1. Memory from `0x00000000` to `0x000A0000` is identity mapped (present)
+2. Memory from `0x000A0000` to `0x00100000` is identity mapped (present +
+   writable)
+3. The VBE framebuffer might be identity mapped as well (present + writable,
+   and only if `ENABLE_FRAMEBUFFER=1` is passed to `make`)
+4. The kernel sections are identity mapped with the correct flags for each
+   section
+5. The multiboot information is identity mapped
+6. The multiboot modules are identity mapped with the correct flags (in our
+   case, it is the init ramdisk)
+7. The memory allocated for the frame allocator is then identity mapped
+
+In addition, `paging_init()` will:
+
+1. enable the write protection
+2. enable the no-execute feature
+3. create a guard page
+
+### Memory map
+
+#### Virtual address space
+
+- `0x00000000` to `0x00100000`: the first 1MiB area is reserved
+- `0x00100000`: the kernel code and data and multiboot modules
+- `0x0020xxxx`: after the end of the previous area (which is computed at runtime
+   using the multiboot information), we allocate some space for the frame
+   allocator
+- `0x10000000`: kernel heap area (we currently have a fixed heap size)
+- `0x40000000`: user space
+
 ## License
 
 willOS is released under the MIT License. See the bundled

--- a/bochsrc.txt
+++ b/bochsrc.txt
@@ -6,3 +6,4 @@ ata0-master: type=cdrom, path=./build/willOS.iso, status=inserted
 com1: enabled=1, mode=file, dev=./logs/debug.log
 
 cpu: reset_on_triple_fault=0
+debug: cpu0=report

--- a/src/asm/boot.asm
+++ b/src/asm/boot.asm
@@ -186,6 +186,7 @@ error:
 ; -----------------------------------------------------------------------------
 section .bss
 align 4096
+
 p4_table:
   ; `resb` means 'reserves bytes'
   resb 4096
@@ -203,6 +204,7 @@ stack_top:
 ; The processor is still in a 32-bit compatibility submode. To actually execute
 ; 64-bit code, we need to set up a new Global Descriptor Table.
 section .rodata
+
 gdt64:
   ; .null_1 / 0x00
   dq 0
@@ -284,6 +286,7 @@ extern kmain
 
 section .text
 bits 64
+
 long_mode_start:
   ; load 0 into all data segment registers
   mov ax, 0

--- a/src/core/gdt.h
+++ b/src/core/gdt.h
@@ -1,8 +1,12 @@
 #ifndef CORE_GDT_H
 #define CORE_GDT_H
 
+#include <sys/types.h>
+
+// See: `src/asm/boot.asm`.
 #define KERNEL_BASE_SELECTOR 0x08
 #define USER_BASE_SELECTOR   0x18
+#define TSS_SEGMENT          0x30
 
 typedef struct gdt_descriptor
 {

--- a/src/core/multiboot.h
+++ b/src/core/multiboot.h
@@ -139,6 +139,8 @@ typedef struct reserved_areas
   uint64_t kernel_end;
   uint64_t multiboot_start;
   uint64_t multiboot_end;
+  uint64_t start;
+  uint64_t end;
 } reserved_areas_t;
 
 typedef struct multiboot_color

--- a/src/core/tss.c
+++ b/src/core/tss.c
@@ -1,0 +1,21 @@
+#include "tss.h"
+#include <core/gdt.h>
+
+// Defined in `src/asm/boot.asm`.
+extern tss_t tss;
+extern gdt_table_t gdt64;
+
+void tss_init()
+{
+  uint64_t tss_base = ((uint64_t)&tss);
+
+  gdt64.tss_low.base15_0 = tss_base & 0xffff;
+  gdt64.tss_low.base23_16 = (tss_base >> 16) & 0xff;
+  gdt64.tss_low.base31_24 = (tss_base >> 24) & 0xff;
+  gdt64.tss_low.limit15_0 = sizeof(tss_t);
+  gdt64.tss_high.limit15_0 = (tss_base >> 32) & 0xffff;
+  gdt64.tss_high.base15_0 = (tss_base >> 48) & 0xffff;
+
+  // Load the TSS.
+  __asm__("ltr %%ax" : : "a"(TSS_SEGMENT));
+}

--- a/src/core/tss.h
+++ b/src/core/tss.h
@@ -1,6 +1,8 @@
 #ifndef CORE_TSS_H
 #define CORE_TSS_H
 
+#include <sys/types.h>
+
 typedef struct tss
 {
   uint32_t reserved0;
@@ -19,5 +21,7 @@ typedef struct tss
   uint16_t reserved3;
   uint16_t iopb_offset;
 } tss_t;
+
+void tss_init();
 
 #endif

--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -148,11 +148,15 @@ void kmain(uint64_t addr)
   console_init(&entry->common);
 
   print_welcome_message();
+
+  print_step("initializing TSS");
+  tss_init();
   print_debug_gdt();
+  print_debug_tss();
+  print_ok();
 
   print_step("initializing interrupt service routine");
   isr_init();
-  print_debug_tss();
   print_ok();
 
   print_step("initializing paging");

--- a/src/kernel/kshell.c
+++ b/src/kernel/kshell.c
@@ -114,6 +114,7 @@ void selftest()
   test("kshell");
 
   print_selftest_header("memory");
+  printf("  simple test with malloc()/free()\n");
   char* str = (void*)0x42;
   printf("  pointer before malloc(): p=%p\n", str);
   int str_len = 9;
@@ -125,6 +126,17 @@ void selftest()
     printf("  success! p=%p", str);
     strncpy(str, "it works", str_len);
     printf(" and value is: %s\n", str);
+    free(str);
+  }
+
+  printf("  now allocating a large chunk of memory...\n");
+  printf("  pointer before malloc(): p=%p\n", str);
+  str = (char*)malloc(1024 * 1024 * 5 * sizeof(char));
+
+  if (str == 0) {
+    printf("  failed\n");
+  } else {
+    printf("  success!\n");
     free(str);
   }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -8,6 +8,7 @@
 #define ANSICOLOR_FG_CYAN      "\x1b[36m"
 #define ANSICOLOR_FG_LIGHTGRAY "\x1b[90m"
 #define ANSICOLOR_FG_YELLOW    "\x1b[33m"
+#define ANSICOLOR_FG_RED       "\x1b[31m"
 
 #ifdef ENABLE_LOGS_FOR_TESTS
 
@@ -87,5 +88,7 @@ static const uint16_t serial_com1 = SERIAL_COM1;
 #endif // ENABLE_KERNEL_DEBUG || ENABLE_LOGS_FOR_TESTS
 
 #define INFO(format, ...) LOG("INFO", ANSICOLOR_FG_YELLOW, format, __VA_ARGS__)
+
+#define ERROR(format, ...) LOG("ERROR", ANSICOLOR_FG_RED, format, __VA_ARGS__)
 
 #endif

--- a/src/mmu/alloc.c
+++ b/src/mmu/alloc.c
@@ -6,20 +6,21 @@
 #include <string.h>
 #include <sys/types.h>
 
-uint64_t heap_end_page;
-uint64_t heap_start_page;
-bitmap_t allocated_pages[(MAX_PAGES / BITS_PER_WORD) + 1] = { 0 };
+static uint64_t heap_end_page = 0;
+static uint64_t heap_start_page = 0;
+static bitmap_t allocated_pages[(MAX_PAGES / BITS_PER_WORD) + 1] = { 0 };
 
 void alloc_init()
 {
   heap_end_page = page_containing_address(HEAP_START + HEAP_SIZE - 1);
   heap_start_page = page_containing_address(HEAP_START);
 
-  INFO("initialized heap allocator with heap_start_page=%u heap_end_page=%u "
-       "used_count=%d",
-       heap_start_page,
-       heap_end_page,
-       alloc_get_used_count());
+  INFO(
+    "initialized heap allocator with heap_start_page=%llu heap_end_page=%llu "
+    "used_count=%llu",
+    heap_start_page,
+    heap_end_page,
+    alloc_get_used_count());
 }
 
 int liballoc_lock()

--- a/src/mmu/frame.h
+++ b/src/mmu/frame.h
@@ -60,15 +60,8 @@ uint64_t frame_get_used_count();
  */
 uint64_t frame_get_max_count();
 
-/**
- * Marks a frame as used.
- *
- * @param physical_address a physical address (frame)
- */
-void frame_mark_as_used(uint64_t physical_address);
-
 // The declarations below are for testing purposes.
-void _frame_init(reserved_areas_t* reserved, multiboot_tag_mmap_t* mmap);
-void _frame_init_bitmap(bitmap_t* addr);
+void _frame_init(reserved_areas_t* reserved_areas, multiboot_tag_mmap_t* _mmap);
+void _frame_set_bitmap(bitmap_t* bitmap);
 
 #endif

--- a/src/mmu/paging.c
+++ b/src/mmu/paging.c
@@ -36,13 +36,12 @@ void paging_set_entry(page_entry_t* entry, uint64_t addr, uint64_t flags);
 opt_uint64_t paging_frame_allocate();
 void paging_frame_deallocate(frame_number_t frame_number);
 
-static page_table_t* active_p4_table = (page_table_t*)P4_TABLE;
-static bool can_deallocate_frames = false;
-
-extern void load_p4(uint64_t addr);
-
 extern uint64_t frames_for_bitmap;
 extern bitmap_t* allocated_frames;
+extern void load_p4(uint64_t addr);
+
+static page_table_t* active_p4_table = (page_table_t*)P4_TABLE;
+static bool can_deallocate_frames = false;
 
 void paging_init(multiboot_info_t* mbi)
 {
@@ -54,7 +53,7 @@ void paging_init(multiboot_info_t* mbi)
 void remap_kernel(multiboot_info_t* mbi)
 {
   uint64_t inactive_page_table_frame = paging_frame_allocate().value;
-  page_number_t temporary_page = page_containing_address(0xcafebabe);
+  page_number_t temporary_page = 0xcafec000;
 
   map_page_to_frame(temporary_page,
                     inactive_page_table_frame,
@@ -90,8 +89,15 @@ void remap_kernel(multiboot_info_t* mbi)
   // We shouldn't deallocate the `inactive_page_table_frame`.
   can_deallocate_frames = true;
 
-  identity_map(0xB8000, PAGING_FLAG_PRESENT | PAGING_FLAG_WRITABLE);
-  MMU_DEBUG("%s", "mapped VGA!");
+  // Identity map first 1 MB.
+  // See: https://wiki.osdev.org/Memory_Map_(x86)
+  for (uint64_t addr = 0; addr < 0x000A0000; addr += PAGE_SIZE) {
+    identity_map(addr, PAGING_FLAG_PRESENT);
+  }
+  for (uint64_t addr = 0x000A0000; addr < 0x100000; addr += PAGE_SIZE) {
+    identity_map(addr, PAGING_FLAG_PRESENT | PAGING_FLAG_WRITABLE);
+  }
+  MMU_DEBUG("%s", "mapped first 1MB!");
 
   multiboot_tag_framebuffer_t* entry =
     (multiboot_tag_framebuffer_t*)find_multiboot_tag(
@@ -108,10 +114,7 @@ void remap_kernel(multiboot_info_t* mbi)
     }
   }
 
-  identity_map(0x0, PAGING_FLAG_PRESENT | PAGING_FLAG_WRITABLE);
-  MMU_DEBUG("%s", "mapped interrupt vector table!");
-
-  // Allocated frames
+  // Bitmap for allocated frames.
   MMU_DEBUG("mapping %d pages for frame allocator, starting at addr=%p",
             frames_for_bitmap,
             allocated_frames);
@@ -119,7 +122,7 @@ void remap_kernel(multiboot_info_t* mbi)
     identity_map((uint64_t)allocated_frames + (i * PAGE_SIZE),
                  PAGING_FLAG_PRESENT | PAGING_FLAG_WRITABLE);
   }
-  MMU_DEBUG("%s", "pages for frame allocator mapped");
+  MMU_DEBUG("%s", "pages for frame allocator mapped!");
 
   MMU_DEBUG("%s", "mapping elf sections");
   multiboot_tag_elf_sections_t* tag =
@@ -225,10 +228,6 @@ void enable_write_protection()
 void zero_table(page_table_t* table)
 {
   memset((void*)table, 0, sizeof(page_table_t));
-
-  for (uint32_t i = 0; i < PAGE_ENTRIES; i++) {
-    table->entries[i].packed = 0;
-  }
 }
 
 page_table_t* next_table_address(page_table_t* table, uint64_t index)
@@ -393,8 +392,8 @@ void map_page_to_frame(page_number_t page_number,
                        uint64_t frame,
                        uint64_t flags)
 {
-  MMU_DEBUG("mapping page=%u (start_addr=%p) to frame=%u (start_addr=%p) with "
-            "flags=%#x",
+  MMU_DEBUG("mapping page=%llu (start_addr=%p) to frame=%llu (start_addr=%p) "
+            "with flags=%#x",
             page_number,
             page_start_address(page_number),
             frame_containing_address(frame),
@@ -646,9 +645,4 @@ void identity_map(uint64_t address, uint64_t flags)
 {
   page_number_t page = page_containing_address(address);
   map_page_to_frame(page, address, flags);
-#ifdef TEST_ENV
-  test_frame_mark_as_used(address);
-#else
-  frame_mark_as_used(address);
-#endif
 }

--- a/test/mmu/frame.c
+++ b/test/mmu/frame.c
@@ -13,28 +13,30 @@ void kernel_panic(const char* format, ...)
 
 int main()
 {
-  reserved_areas_t reserved_areas = { .kernel_start = 0x10000,
-                                      .kernel_end = 0x11000,
-                                      .multiboot_start = 0x12000,
-                                      .multiboot_end = 0x13500 };
+  reserved_areas_t reserved_areas = { .kernel_start = 0x1001,
+                                      .kernel_end = 0x1100,
+                                      .multiboot_start = 0x1200,
+                                      .multiboot_end = 0x2050,
+                                      .start = 0x1000,
+                                      .end = 0x2050 };
 
   multiboot_tag_mmap_t* mmap = malloc(
     sizeof(multiboot_tag_mmap_t) + sizeof(multiboot_mmap_entry_t) * NB_ENTRIES);
 
   multiboot_mmap_entry_t entries[NB_ENTRIES] = {
-    { .type = MULTIBOOT_MEMORY_AVAILABLE, .addr = 0x000000, .len = 0x6000 },
-    { .type = MULTIBOOT_MEMORY_RESERVED, .addr = 0x007000, .len = 0x5000 },
-    { .type = MULTIBOOT_MEMORY_AVAILABLE, .addr = 0x012000, .len = 0x8000 },
+    { .type = MULTIBOOT_MEMORY_AVAILABLE, .addr = 0x000000, .len = 0x10000 },
+    { .type = MULTIBOOT_MEMORY_RESERVED, .addr = 0x010000, .len = 0x05000 },
+    { .type = MULTIBOOT_MEMORY_AVAILABLE, .addr = 0x015000, .len = 0x03000 },
   };
   mmap->size = sizeof(multiboot_mmap_entry_t) * NB_ENTRIES;
   mmap->entry_size = sizeof(multiboot_mmap_entry_t);
   memcpy(mmap->entries, entries, sizeof(multiboot_mmap_entry_t) * NB_ENTRIES);
 
-  bitmap_t* bitmap = (bitmap_t*)malloc(PAGE_SIZE);
+  bitmap_t* bitmap = (bitmap_t*)calloc(1, PAGE_SIZE);
 
   describe("frame_init()");
+  _frame_set_bitmap(bitmap);
   _frame_init(&reserved_areas, mmap);
-  _frame_init_bitmap(bitmap);
   end_describe();
 
   describe("frame_deallocate()");
@@ -44,22 +46,39 @@ int main()
   }
   end_describe();
 
+  // This is the start address of the allocatable frames.
+  uint64_t start_address = 0x4000;
+
   describe("frame_allocate()");
-  for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < 11; i++) {
     opt_uint64_t frame = frame_allocate();
 
-    assert(frame.value == (0x1000 * i), "allocates a frame");
+    assert(frame.value == (start_address + 0x1000 * i), "allocates a frame");
     uint64_t frame_num = frame_containing_address(frame.value);
-    assert(frame_num == i, "returns the frame number");
+    assert(frame_num == frame_containing_address(start_address) + i,
+           "returns the frame number");
     assert(frame_start_address(frame_num) == frame.value,
            "returns the correct address");
   }
+
   opt_uint64_t frame = frame_allocate();
-  assert(frame.value == 0x014000, "allocates a frame after reserved area");
+  assert(frame.value == 0xf000,
+         "allocates the last frame in the first available area");
+
+  for (int i = 0; i < 3; i++) {
+    opt_uint64_t frame = frame_allocate();
+    assert(frame.value == 0x15000 + (i * 0x1000),
+           "allocates a frame after reserved area (2nd area)");
+  }
+  end_describe();
+
+  describe("frame_allocate() - out of memory");
+  frame = frame_allocate();
+  assert(frame.has_value == false, "should return no value");
   end_describe();
 
   describe("frame_deallocate()");
-  uint64_t expected_frame = 0x2000;
+  uint64_t expected_frame = 0x5000;
   frame_deallocate(frame_containing_address(expected_frame));
   opt_uint64_t reused_frame = frame_allocate();
   assert(reused_frame.value == expected_frame,

--- a/userland/Makefile.include
+++ b/userland/Makefile.include
@@ -40,7 +40,9 @@ ifeq ($(ENABLE_USERLAND_DEBUG), 1)
 endif
 
 LDFLAGS ?=
-LDFLAGS += -nostdlib -no-pie $(ROOT_DIR)/build/libc-$(OS_NAME).a
+LDFLAGS += -Wl,-Ttext-segment=40000000 \
+					 -nostdlib -no-pie \
+					 $(ROOT_DIR)/build/libc-$(OS_NAME).a
 
 default: $(TARGET)
 


### PR DESCRIPTION
Not directly related but also fixes #248 

---

I think this would be a better frame allocator because we'd skip all lower addresses and memory already used. It looks like it would reserve/skip ~2MB of memory (including the bitmap for the allocated frames). I think this is perfectly fine.