### PR TITLE
Restore cat command to kshell

### DIFF
--- a/src/kshell/cat.c
+++ b/src/kshell/cat.c
@@ -1,0 +1,32 @@
+#include "kshell.h"
+#include <fs/vfs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+void cat(int argc, char* argv[])
+{
+  if (argc < 2) {
+    printf("%s requires an argument\n", argv[0]);
+  }
+
+  for (int i = 1; i < argc; i++) {
+    inode_t f = vfs_namei(argv[i]);
+
+    if (!f) {
+      printf("no such file or directory\n");
+      continue;
+    }
+
+    if (f->type != FS_FILE) {
+      printf("'%s' is not a printable file\n", f->name);
+      vfs_free(f);
+      continue;
+    }
+
+    char buf[512];
+    vfs_read(f, buf, sizeof(buf), 0);
+    printf("%s", buf);
+    vfs_free(f);
+  }
+}

--- a/src/kshell/cat.c
+++ b/src/kshell/cat.c
@@ -28,7 +28,7 @@ void cat(int argc, char* argv[])
     for (int offset = 0, bytes_read = 0;
          (bytes_read = vfs_read(f, buf, sizeof(buf), offset)) > 0;
          offset += bytes_read) {
-      console_write(buf, bytes_read);
+      printf("%s", buf);
     }
 
     vfs_free(f);

--- a/src/kshell/cat.c
+++ b/src/kshell/cat.c
@@ -25,8 +25,12 @@ void cat(int argc, char* argv[])
     }
 
     char buf[512];
-    vfs_read(f, buf, sizeof(buf), 0);
-    printf("%s", buf);
+    for (int offset = 0, bytes_read = 0;
+         (bytes_read = vfs_read(f, buf, sizeof(buf), offset)) > 0;
+         offset += bytes_read) {
+      console_write(buf, bytes_read);
+    }
+
     vfs_free(f);
   }
 }

--- a/src/kshell/kshell.c
+++ b/src/kshell/kshell.c
@@ -22,6 +22,7 @@ static const char* commands[][NB_DOCUMENTED_COMMANDS] = {
   { "help", "print this help message" },
   { "host", "perform a DNS lookup" },
   { "ls", "list files" },
+  { "cat", "print on the standard output" },
   { "net", "show configured network interfaces" },
   { "ntp", "get the time from a time server" },
   { "overflow", "test the stack buffer overflow protection" },
@@ -115,6 +116,8 @@ void run_command()
     help(argc, argv);
   } else if (strcmp(argv[0], "ls") == 0) {
     ls(argc, argv);
+  } else if (strcmp(argv[0], "cat") == 0) {
+    cat(argc, argv);
   } else if (strcmp(argv[0], "selftest") == 0) {
     selftest();
   } else if (strcmp(argv[0], "overflow") == 0) {

--- a/src/kshell/kshell.h
+++ b/src/kshell/kshell.h
@@ -42,6 +42,7 @@ void kshell_run(uint8_t scancode);
 void exec(int argc, char* argv[]);
 void host(int argc, char* argv[]);
 void ls(int argc, char* argv[]);
+void cat(int argc, char* argv[]);
 void net();
 void ntp(int argc, char* argv[]);
 void overflow();


### PR DESCRIPTION
The kshell builtin `cat` command was previously removed in commit 83a747243f9c34773bf661b64e965d9c57e48945.  The command is restored in this change.

Fixes: #242 