### PR TITLE
Fix cat by passing bytes read to printf

### DIFF
--- a/src/kshell/cat.c
+++ b/src/kshell/cat.c
@@ -28,7 +28,7 @@ void cat(int argc, char* argv[])
     for (int offset = 0, bytes_read = 0;
          (bytes_read = vfs_read(f, buf, sizeof(buf), offset)) > 0;
          offset += bytes_read) {
-      printf("%s", buf);
+      printf("%.*s", bytes_read, buf);
     }
 
     vfs_free(f);


### PR DESCRIPTION
The function `vfs_read` simply copies bytes to the buffer and does not add a null terminator.  To address this the number of bytes read is passed to `printf`.