### PR TITLE
tools: add script to fix stacktrace in log files

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -25,3 +25,4 @@ endif
 CC = $(LLVM_PREFIX)clang$(LLVM_SUFFIX)
 LD = $(LLVM_PREFIX)ld.lld$(LLVM_SUFFIX)
 AR = $(LLVM_PREFIX)llvm-ar$(LLVM_SUFFIX)
+NM = $(LLVM_PREFIX)llvm-nm$(LLVM_SUFFIX)

--- a/tools/fix-stacktrace.py
+++ b/tools/fix-stacktrace.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+
+
+SYMBOLS_TABLE = []
+
+
+def load_symbols_table(symbols):
+    with open(symbols, "r") as symbols_file:
+        for line in symbols_file.readlines():
+            [addr, name] = line.split(" ")
+            SYMBOLS_TABLE.append([int(addr, 16), name.strip()])
+
+
+def find_symbol(addr):
+    left = -1
+    right = len(SYMBOLS_TABLE)
+
+    while right - left > 1:
+        mid = (left + right) // 2
+
+        if addr >= SYMBOLS_TABLE[mid][0]:
+            left = mid
+        else:
+            right = mid
+
+    return SYMBOLS_TABLE[left] if left >= 0 else [addr, "(unknown)"]
+
+
+def fix_stacktrace():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("symbols")
+    parser.add_argument("logfile")
+    args = parser.parse_args()
+
+    load_symbols_table(args.symbols)
+
+    with open(args.logfile, "r") as logfile:
+        stacktrace = re.compile('.+kernel_dump_stacktrace.+([0-9A-Z]{16})')
+
+        for line in logfile.readlines():
+            matches = stacktrace.match(line)
+
+            if matches:
+                addr = int(matches.group(1), 16)
+                [symbol_addr, name] = find_symbol(addr)
+                offset = '+0x{:x}'.format(addr - symbol_addr)
+                print(f"{line[:-1]} - {name} {offset}")
+            else:
+                print(line, end="")
+
+
+if __name__ == "__main__":
+    fix_stacktrace()


### PR DESCRIPTION
refs #275

---

Before:

```
  DEBUG    | src/arch/x86_64/kshell/kshell.c:108:run_command(): command='selftest' argc=1
  DEBUG    | src/arch/x86_64/kernel/panic.c:30:kernel_dump_stacktrace(): kernel stacktrace:
  DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   00000000001163B3
  DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   0000000000115941
  DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   0000000000115BE1
  DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   00000000001152BF
  DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   000000000010935B
```

After:

```
$ ./tools/fix-stacktrace.py build/x86_64/symbols.txt log/debug.log
[...]

DEBUG    | src/arch/x86_64/kshell/kshell.c:108:run_command(): command='selftest' argc=1
DEBUG    | src/arch/x86_64/kernel/panic.c:30:kernel_dump_stacktrace(): kernel stacktrace:
DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   00000000001163B3 - selftest +0x63
DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   0000000000115941 - run_command +0x271
DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   0000000000115BE1 - kshell_run +0x181
DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   00000000001152BF - kmain +0x107f
DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace():   000000000010935B - long_mode_start +0x13
```