### PR TITLE
Revert "linker: discard .debug* sections"

### DIFF
--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -35,12 +35,11 @@ SECTIONS {
         . = ALIGN(4K);
     }
 
-    /* get rid of unnecessary compiler bits */
+    /* get rid of unnecessary gcc bits */
     /DISCARD/ :
     {
         *(.comment)
         *(.eh_frame)
         *(.note.gnu.build-id)
-        *(.debug*)
     }
 }


### PR DESCRIPTION
Reverts willdurand/willOS#276

This breaks `addr2line` and `llvm-symbolizer` because it removes the source code annotations.