### PR TITLE
libc: add null char when writing single chars

### DIFF
--- a/src/libc/putchar.c
+++ b/src/libc/putchar.c
@@ -5,5 +5,6 @@
 
 void putchar(char c)
 {
-  write(STDOUT, &c, 1);
+  // Make sure we write a null-terminated string.
+  write(STDOUT, (char[]){ c, '\0' }, 1);
 }

--- a/src/libc/willos/log.c
+++ b/src/libc/willos/log.c
@@ -38,7 +38,8 @@ void willos_log_putchar(char c, void* arg)
     return;
   }
 
-  write(com1_fd, &c, 1);
+  // Make sure we write a null-terminated string.
+  write(com1_fd, (char[]){ c, '\0' }, 1);
 }
 
 #endif


### PR DESCRIPTION
This patch fixes a bug where userland debug logs were not written correctly because `serial_print()` failed to write the correct data (due to `strlen()`).