### PR TITLE
kernel: load debug symbols as a grub module and use them in kernel stacktraces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ INITRD_DIR     = initrd
 INITRD_TAR     = initrd.tar
 INITRD         := $(ISO_BOOT_DIR)/$(INITRD_TAR)
 GIT_HASH       := $(shell git rev-parse --short HEAD)
-SYMBOLS_FILE   := $(ARCH_BUILD_DIR)/symbols.txt
+SYMBOLS_TXT    := symbols.txt
+SYMBOLS        := $(ISO_BOOT_DIR)/$(SYMBOLS_TXT)
 LOG_FILE       = $(LOG_DIR)/$(BUILD_MODE).log
 
 # This should be a bitmap font.
@@ -138,12 +139,14 @@ set default=$(GRUB_DEFAULT)
 menuentry "$(OS_NAME) $(BUILD_MODE)" {
 	multiboot2 /boot/$(KERNEL_BIN) $(GRUB_KERNEL_CMDLINE)
 	module2 /boot/$(INITRD_TAR) initrd
+	module2 /boot/$(SYMBOLS_TXT) symbols
 	boot
 }
 
 menuentry "$(OS_NAME) $(BUILD_MODE) (kernel mode)" {
 	multiboot2 /boot/$(KERNEL_BIN) kshell
 	module2 /boot/$(INITRD_TAR) initrd
+	module2 /boot/$(SYMBOLS_TXT) symbols
 	boot
 }
 endef
@@ -173,7 +176,7 @@ $(GRUB_DIR): $(ISO_BOOT_DIR)
 $(KERNEL): $(ISO_BOOT_DIR) $(DIST_DIR) $(LIBK_ASM_OBJECTS) $(LIBK_OBJECTS) $(KERNEL_CONSOLE_FONT)
 	$(PROGRESS) "LD" $@
 	$(LD) --nmagic --output=$@ --script=$(LINKER) $(LIBK_ASM_OBJECTS) $(LIBK_OBJECTS) $(KERNEL_CONSOLE_FONT)
-	$(NM) $@ | awk '{ print $$1, $$3 }' | sort > $(SYMBOLS_FILE)
+	$(NM) $@ | awk '{ print $$1, $$3 }' | sort > $(SYMBOLS)
 	cp $@ $(DIST_DIR)
 
 kernel: ## compile the kernel

--- a/README.md
+++ b/README.md
@@ -131,24 +131,25 @@ There is also `ENABLE_ALL_DEBUG` to turn all debug logs on.
 
 ##### Stacktraces
 
-Log files may contain stacktraces:
+Log files may contain stacktraces without debug symbols if the symbols haven't
+been loaded via GRUB:
 
 ```
 [...]
 DEBUG    | src/arch/x86_64/kshell/kshell.c:108:run_command(): command='selftest' argc=1
 DEBUG    | src/arch/x86_64/kernel/panic.c:30:kernel_dump_stacktrace(): kernel stacktrace:
-DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 00000000001163B3
-DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 0000000000115941
-DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 0000000000115BE1
-DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 00000000001152BF
-DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 000000000010935B
+DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 00000000001163B3 - ???+0x0
+DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 0000000000115941 - ???+0x0
+DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 0000000000115BE1 - ???+0x0
+DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 00000000001152BF - ???+0x0
+DEBUG    | src/arch/x86_64/kernel/panic.c:39:kernel_dump_stacktrace(): 000000000010935B - ???+0x0
 ```
 
 Use the `tools/fix-stacktrace.py` script to add missing symbol names to the
 output:
 
 ```
-$ ./tools/fix-stacktrace.py build/x86_64/symbols.txt log/debug.log
+$ ./tools/fix-stacktrace.py build/x86_64/isofiles/boot/symbols.txt log/debug.log
 [...]
 DEBUG    | src/arch/x86_64/kshell/kshell.c:108:run_command(): command='selftest' argc=1
 DEBUG    | src/arch/x86_64/kernel/panic.c:30:kernel_dump_stacktrace(): kernel stacktrace:

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -25,4 +25,6 @@ int atoi(char* s);
 // Returns the absolute value of `x`.
 int abs(int x);
 
+long int strtol_wip(const char* str, char** end, int base);
+
 #endif

--- a/include/string.h
+++ b/include/string.h
@@ -40,6 +40,10 @@ size_t strspn(const char* s1, const char* s2);
 
 char* strchr(const char* s, int c);
 
+// Like strchr() except that when `c` is not found in `s`, it returns a pointer
+// to the null byte at the end of `s`, rather than `NULL`.
+char* strchrnul(const char* s, int c);
+
 // Scans the initial `n` bytes of the memory area pointed to by `str` for the
 // first instance of `c`. Both `c` and the bytes of the memory area pointed to
 // by `str` are interpreted as unsigned char.

--- a/src/arch/x86_64/kernel/kmain.c
+++ b/src/arch/x86_64/kernel/kmain.c
@@ -39,6 +39,7 @@ void print_debug_gdt();
 void print_debug_tss();
 void load_modules(multiboot_info_t* mbi);
 void load_initrd(multiboot_tag_module_t* module);
+void load_symbols(multiboot_tag_module_t* module, uint64_t size);
 
 void print_debug_tss()
 {
@@ -135,12 +136,22 @@ void load_modules(multiboot_info_t* mbi)
        tag = (multiboot_tag_t*)((uint8_t*)tag + ((tag->size + 7) & ~7))) {
     if (tag->type == MULTIBOOT_TAG_TYPE_MODULE) {
       multiboot_tag_module_t* module = (multiboot_tag_module_t*)tag;
+      uint64_t size = module->mod_end - module->mod_start;
 
       if (strcmp(module->cmdline, "initrd") == 0) {
         load_initrd(module);
+      } else if (strcmp(module->cmdline, "symbols") == 0) {
+        load_symbols(module, size);
       }
     }
   }
+}
+
+void load_symbols(multiboot_tag_module_t* module, uint64_t size)
+{
+  print_step("loading debug symbols");
+  kernel_load_symbols(module->mod_start, size);
+  print_ok();
 }
 
 void load_initrd(multiboot_tag_module_t* module)

--- a/src/arch/x86_64/kernel/panic.c
+++ b/src/arch/x86_64/kernel/panic.c
@@ -2,6 +2,19 @@
 #include <core/isr.h>
 #include <drivers/vga_text.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char* kernel_find_symbol(uint64_t* addr);
+
+static char* symbols = NULL;
+
+void kernel_load_symbols(uint64_t addr, uint64_t size)
+{
+  symbols = (char*)malloc(sizeof(char) * (size + 1));
+  memcpy(symbols, (void*)addr, size);
+  symbols[size] = 0;
+}
 
 void kernel_panic(const char* format, ...)
 {
@@ -34,10 +47,60 @@ void kernel_dump_stacktrace()
 
   while (stackframe != NULL) {
     uint64_t address = stackframe->rip;
+    uint64_t symbol_addr = address;
 
-    printf("     %p\n", address);
-    DEBUG("  %p", address);
+    char* symbol = kernel_find_symbol(&symbol_addr);
+    char* name = symbol ? symbol : "???";
+    uint64_t offset = symbol ? (address - symbol_addr) : 0;
+
+    printf("     %p - %s+0x%x\n", address, name, offset);
+    DEBUG("  %p - %s+0x%x", address, name, offset);
+
+    if (symbol) {
+      free(symbol);
+    }
 
     stackframe = stackframe->rbp;
   }
+}
+
+char* kernel_find_symbol(uint64_t* addr)
+{
+  char* retval = NULL;
+
+  char* line = symbols;
+  uint64_t size = strlen(symbols);
+
+  uint64_t prev_symbol_addr = 0;
+  char* prev_symbol_name = NULL;
+  char* symbol_name = NULL;
+
+  // Linear lookup, not great (as in not efficient) but it works.
+  while (line && line < (char*)symbols + size) {
+    uint64_t symbol_addr = strtol_wip(line, &symbol_name, 16);
+    symbol_name += 1;
+
+    if (!prev_symbol_addr) {
+      prev_symbol_addr = symbol_addr;
+      prev_symbol_name = symbol_name;
+    }
+
+    if (symbol_addr > *addr) {
+      if (prev_symbol_name != NULL) {
+        uint8_t len =
+          (uint8_t)(strchrnul(prev_symbol_name, '\n') - prev_symbol_name) + 1;
+        retval = (char*)malloc(sizeof(char) * (len + 1));
+        strncpy(retval, prev_symbol_name, len);
+        *addr = prev_symbol_addr;
+      }
+
+      break;
+    }
+
+    prev_symbol_addr = symbol_addr;
+    prev_symbol_name = symbol_name;
+    line = strchr(line, '\n') + 1;
+  }
+
+  return retval;
 }

--- a/src/arch/x86_64/kernel/panic.h
+++ b/src/arch/x86_64/kernel/panic.h
@@ -3,6 +3,7 @@
 #define CORE_PANIC_H
 
 #include <logging.h>
+#include <stdint.h>
 
 #define __PANIC(format, ...)                                                   \
   DEBUG(format "%s", __VA_ARGS__);                                             \
@@ -27,6 +28,17 @@ typedef struct stack_frame
  */
 void kernel_panic(const char* format, ...);
 
+/**
+ * Loads symbols used in stacktraces.
+ *
+ * @param addr the address of the symbols data
+ * @param size the size of the symbols data
+ */
+void kernel_load_symbols(uint64_t addr, uint64_t size);
+
+/**
+ * Prints a stacktrace.
+ */
 void kernel_dump_stacktrace();
 
 #endif

--- a/src/libc/string/strchrnul.c
+++ b/src/libc/string/strchrnul.c
@@ -1,0 +1,12 @@
+#include <string.h>
+
+char* strchrnul(const char* s, int c)
+{
+  char* occurrence = strchr(s, c);
+
+  if (occurrence) {
+    return occurrence;
+  }
+
+  return (char*)s + strlen(s);
+}

--- a/src/libc/strtol.c
+++ b/src/libc/strtol.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+
+// TODO: this function is supposed to implement `strtol()` but it has been
+// written for the kernel stacktrace and does not behave like it should (e.g.,
+// it does not skip spaces and does not support a `base` different than `16`).
+long int strtol_wip(const char* str, char** end, int base)
+{
+  char* ptr = (char*)str;
+  long int value = 0;
+
+  if (base != 16) {
+    return value;
+  }
+
+  while (*ptr != '\0') {
+    uint8_t byte = *ptr;
+
+    if (byte >= '0' && byte <= '9') {
+      byte = byte - '0';
+    } else if (byte >= 'a' && byte <= 'f') {
+      byte = byte - 'a' + 10;
+    } else if (byte >= 'A' && byte <= 'F') {
+      byte = byte - 'A' + 10;
+    } else {
+      if (end != NULL) {
+        *end = ptr;
+      }
+
+      return value;
+    }
+
+    value = (value << 4) | (byte & 0xF);
+    ptr++;
+  }
+
+  return value;
+}

--- a/tools/fix-stacktrace.py
+++ b/tools/fix-stacktrace.py
@@ -38,7 +38,8 @@ def fix_stacktrace():
     load_symbols_table(args.symbols)
 
     with open(args.logfile, "r") as logfile:
-        stacktrace = re.compile('.+kernel_dump_stacktrace.+([0-9A-Z]{16})')
+        stacktrace = re.compile(".+kernel_dump_stacktrace.+([0-9A-Z]{16}).+\\?\\?\\?")
+        offset = len(" - ???+0x0\n")
 
         for line in logfile.readlines():
             matches = stacktrace.match(line)
@@ -46,8 +47,8 @@ def fix_stacktrace():
             if matches:
                 addr = int(matches.group(1), 16)
                 [symbol_addr, name] = find_symbol(addr)
-                offset = '+0x{:x}'.format(addr - symbol_addr)
-                print(f"{line[:-1]} - {name} {offset}")
+                addr_offset = '+0x{:x}'.format(addr - symbol_addr)
+                print(f"{line[:-offset]} - {name}{addr_offset}")
             else:
                 print(line, end="")
 


### PR DESCRIPTION
Fixes https://github.com/willdurand/willOS/issues/275

---

<img width="832" alt="Screen Shot 2021-11-07 at 21 01 43" src="https://user-images.githubusercontent.com/217628/140660007-e6275b83-082d-4f07-a872-63bac762e9f9.png">

