### PR TITLE
build: userland: rename boot-and-exit to testsuite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,13 @@ jobs:
             make fmt
             git diff --exit-code || (echo "\n\nPlease run 'make fmt' to format the code and fix the problem(s) above"; false)
       - run:
-          name: integration tests
+          name: userland test suite
           command: |
             export TERM=xterm
             make clean run-test
+          no_output_timeout: 2m
       - run:
-          name: integration tests with ubsan
+          name: userland test suite with UBSan enabled
           command: |
             export TERM=xterm
             make clean run-test UBSAN=1

--- a/Makefile
+++ b/Makefile
@@ -281,9 +281,8 @@ run-debug: debug
 run-test: ## run the OS in test mode
 run-test: BUILD_MODE = test
 run-test: QEMU_OPTIONS += -curses
-run-test: GRUB_KERNEL_CMDLINE = /bin/boot-and-exit
+run-test: GRUB_KERNEL_CMDLINE = /bin/userland-testsuite
 run-test: run
-	cat initrd/info
 .PHONY: run-test
 
 clean: ## remove build artifacts

--- a/userland/boot-and-exit/Makefile
+++ b/userland/boot-and-exit/Makefile
@@ -1,3 +1,0 @@
-BIN_NAME = boot-and-exit
-
-include ../Makefile.include

--- a/userland/testsuite/Makefile
+++ b/userland/testsuite/Makefile
@@ -1,0 +1,3 @@
+BIN_NAME = userland-testsuite
+
+include ../Makefile.include

--- a/userland/testsuite/main.c
+++ b/userland/testsuite/main.c
@@ -6,6 +6,12 @@
 
 int main()
 {
+  printf("==== userland test suite ====");
+
+#ifndef __willos__
+  printf("This program should be compiled for and executed on willOS\n");
+  return 1;
+#else
   // Invoke some syscalls.
   int fd = open("/dev/null", O_WRONLY);
   int bytes_written = write(fd, NULL, 50);
@@ -14,12 +20,11 @@ int main()
   if (bytes_written == 50) {
     printf("Looks like everything is alright!\n");
 
-#ifdef __willos__
     reboot(REBOOT_CMD_POWER_OFF);
-#endif
 
     return 0;
   }
 
   return 1;
+#endif
 }


### PR DESCRIPTION
This program should run some tests instead of not doing anything given that we
use it in the 'run-test' command. Let's port some of the 'selftest' test cases
into it.