### PR TITLE
Invoke built-in commands in kshell via the GRUB cmdline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,14 @@ jobs:
           title: kernel selftest
           command: make clean run-test GRUB_KERNEL_CMDLINE='kshell selftest'
 
+  kernel-selftest-ubsan:
+    <<: *defaults
+    steps:
+      - setup
+      - run_qemu:
+          title: kernel selftest with UBSan enabled
+          command: make clean run-test GRUB_KERNEL_CMDLINE='kshell selftest' UBSAN=1
+
   kernel-selftest-10-times:
     <<: *defaults
     steps:
@@ -118,4 +126,5 @@ workflows:
       - userland-test-suite
       - userland-test-suite-ubsan
       - kernel-selftest
+      - kernel-selftest-ubsan
       - kernel-selftest-10-times

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,12 @@ commands:
       command:
         type: string
     steps:
-      - run: echo 'export TERM=xterm' >> $BASH_ENV
       - run:
           name: << parameters.title >>
           command: << parameters.command >>
           no_output_timeout: 2m
+          environment:
+            TERM: xterm-256color
 
 jobs:
   build-debug:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,15 @@ jobs:
           title: kernel selftest
           command: make clean run-test GRUB_KERNEL_CMDLINE='kshell selftest'
 
+  kernel-selftest-10-times:
+    <<: *defaults
+    steps:
+      - setup
+      - run_qemu:
+          title: kernel selftest ran 10 times
+          command: |
+            make clean run-test GRUB_KERNEL_CMDLINE="$(echo "kshell$(printf ' selftest%.0s' {1..10})")"
+
 workflows:
   default-workflow:
     jobs:
@@ -108,3 +117,4 @@ workflows:
       - userland-test-suite
       - userland-test-suite-ubsan
       - kernel-selftest
+      - kernel-selftest-10-times

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,19 @@ commands:
           command: |
             cp .circleci/willosconfig willosconfig
 
+  run_qemu:
+    parameters:
+      title:
+        type: string
+      command:
+        type: string
+    steps:
+      - run: echo 'export TERM=xterm' >> $BASH_ENV
+      - run:
+          name: << parameters.title >>
+          command: << parameters.command >>
+          no_output_timeout: 2m
+
 jobs:
   build-debug:
     <<: *defaults
@@ -66,23 +79,25 @@ jobs:
     <<: *defaults
     steps:
       - setup
-      - run:
-          name: userland test suite
-          command: |
-            export TERM=xterm
-            make clean run-test
-          no_output_timeout: 2m
+      - run_qemu:
+          title: userland test suite
+          command: make clean run-test
 
   userland-test-suite-ubsan:
     <<: *defaults
     steps:
       - setup
-      - run:
-          name: userland test suite with UBSan enabled
-          command: |
-            export TERM=xterm
-            make clean run-test UBSAN=1
-          no_output_timeout: 2m
+      - run_qemu:
+          title: userland test suite with UBSan enabled
+          command: make clean run-test UBSAN=1
+
+  kernel-selftest:
+    <<: *defaults
+    steps:
+      - setup
+      - run_qemu:
+          title: kernel selftest
+          command: make clean run-test GRUB_KERNEL_CMDLINE='kshell selftest'
 
 workflows:
   default-workflow:
@@ -92,3 +107,4 @@ workflows:
       - unit-tests
       - userland-test-suite
       - userland-test-suite-ubsan
+      - kernel-selftest

--- a/src/arch/x86_64/kernel/kmain.c
+++ b/src/arch/x86_64/kernel/kmain.c
@@ -337,20 +337,6 @@ void kmain(uint64_t addr)
   multiboot_tag_string_t* cmdline = (multiboot_tag_string_t*)find_multiboot_tag(
     mbi, MULTIBOOT_TAG_TYPE_CMDLINE);
 
-  if (cmdline && strcmp(cmdline->string, "kshell") == 0) {
-    printf("kernel: loading kshell...\n");
-    INFO("%s", "loading kshell");
-
-    kshell_init();
-
-    while (1) {
-      kshell_run(keyboard_get_scancode());
-      // This allows the CPU to enter a sleep state in which it consumes much
-      // less energy. See: https://en.wikipedia.org/wiki/HLT_(x86_instruction)
-      __asm__("hlt");
-    }
-  }
-
   int argc = 1;
   char* _cmdline = strdup(cmdline->string);
   strtok(_cmdline, " ");
@@ -369,8 +355,22 @@ void kmain(uint64_t addr)
   argv[argc] = NULL;
   free(_cmdline);
 
+  if (strcmp(argv[0], "kshell") == 0) {
+    printf("kernel: loading %s...\n", argv[0]);
+    INFO("kernel: loading %s...", argv[0]);
+
+    kshell_init(argc, argv);
+
+    while (1) {
+      kshell_run(keyboard_get_scancode());
+      // This allows the CPU to enter a sleep state in which it consumes much
+      // less energy. See: https://en.wikipedia.org/wiki/HLT_(x86_instruction)
+      __asm__("hlt");
+    }
+  }
+
   printf("kernel: switching to usermode... (%s)\n", argv[0]);
-  INFO("switching to usermode (%s)", argv[0]);
+  INFO("kernel: switching to usermode... (%s)", argv[0]);
   k_execv(argv[0], argv);
 
   PANIC("unexpectedly reached end of kmain");

--- a/src/arch/x86_64/kshell/kshell.c
+++ b/src/arch/x86_64/kshell/kshell.c
@@ -156,7 +156,7 @@ void reset_readline()
   }
 }
 
-void kshell_init()
+void kshell_init(int argc, char* argv[])
 {
   printf("\nThis is willOS kernel shell. Type 'help' for more information.\n"
          "Protip: switch to usermode with the 'usermode' command.\n\n");

--- a/src/arch/x86_64/kshell/kshell.c
+++ b/src/arch/x86_64/kshell/kshell.c
@@ -15,18 +15,19 @@ static bool caps_lock_mode = false;
 static bool ctrl_mode = false;
 static bool shift_mode = false;
 
-#define NB_DOCUMENTED_COMMANDS 11
+#define NB_DOCUMENTED_COMMANDS 12
 
 static const char* commands[][NB_DOCUMENTED_COMMANDS] = {
+  { "cat", "print on the standard output" },
   { "exec", "execute a program in user mode" },
   { "help", "print this help message" },
   { "host", "perform a DNS lookup" },
   { "ls", "list files" },
-  { "cat", "print on the standard output" },
   { "net", "show configured network interfaces" },
   { "ntp", "get the time from a time server" },
   { "overflow", "test the stack buffer overflow protection" },
   { "ping", "ping an IPv4 address" },
+  { "poweroff", "power off the system" },
   { "selftest", "run the kernel test suite" },
   { "usermode", "switch to usermode (alias for 'exec /bin/init -s')" },
 };
@@ -135,6 +136,8 @@ void run_command()
   } else if (strcmp(argv[0], "usermode") == 0) {
     char* args[] = { "exec", "/bin/init", "-s" };
     exec(3, args);
+  } else if (strcmp(argv[0], "poweroff") == 0) {
+    power_off();
   } else {
     printf("invalid kshell command\n");
   }
@@ -158,6 +161,18 @@ void reset_readline()
 
 void kshell_init(int argc, char* argv[])
 {
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      if (strcmp(argv[i], "selftest") == 0) {
+        selftest();
+      } else {
+        printf("unsupported command: %s\n", argv[i]);
+      }
+    }
+
+    power_off();
+  }
+
   printf("\nThis is willOS kernel shell. Type 'help' for more information.\n"
          "Protip: switch to usermode with the 'usermode' command.\n\n");
 

--- a/src/arch/x86_64/kshell/kshell.h
+++ b/src/arch/x86_64/kshell/kshell.h
@@ -39,14 +39,15 @@ void kshell_init(int argc, char* argv[]);
  */
 void kshell_run(uint8_t scancode);
 
+void cat(int argc, char* argv[]);
 void exec(int argc, char* argv[]);
 void host(int argc, char* argv[]);
 void ls(int argc, char* argv[]);
-void cat(int argc, char* argv[]);
 void net();
 void ntp(int argc, char* argv[]);
 void overflow();
 void ping(int argc, char* argv[]);
+void power_off();
 void selftest();
 
 #endif

--- a/src/arch/x86_64/kshell/kshell.h
+++ b/src/arch/x86_64/kshell/kshell.h
@@ -28,7 +28,7 @@
 /**
  * Initializes the kernel shell.
  */
-void kshell_init();
+void kshell_init(int argc, char* argv[]);
 
 /**
  * Runs the kernel shell. This function takes a `scancode` as input and handles

--- a/src/arch/x86_64/kshell/power_off.c
+++ b/src/arch/x86_64/kshell/power_off.c
@@ -1,0 +1,8 @@
+#include "kshell.h"
+#include <sys/reboot.h>
+#include <sys/syscall.h>
+
+void power_off()
+{
+  reboot(REBOOT_CMD_POWER_OFF);
+}


### PR DESCRIPTION
This allows to pass arguments to `kshell_init()` in addition to reusing the
exact same code for two code paths. When arguments are passed to the kshell,
the system is powered off after having handled the different arguments.

The idea is to be able to tell the kshell to run some of its built-in commands
automatically, and then the system is powered off (abruptly). In this PR, the
code to run `selftest` has been added and a new `poweroff` built-in command
has been introduced to.. power off the system.